### PR TITLE
[fix] 바텀시트에서 앨범커버 누르면 멈춤, 재생

### DIFF
--- a/sogeun-pwa/src/App.tsx
+++ b/sogeun-pwa/src/App.tsx
@@ -11,13 +11,18 @@ import ProfilePage from "./pages/ProfilePage";
 import type { Track } from "./pages/SearchPage";
 
 const MainScreen = () => {
+  // 1. 오디오 객체를 담을 ref가 부모에 있어야 합니다.
+  const audioRef = useRef<HTMLAudioElement | null>(null);
   const [currentPage, setCurrentPage] = useState<"gps" | "search">("gps");
   const [currentTrack, setCurrentTrack] = useState<Track | null>(null);
+
   const [bgmUrl, setBgmUrl] = useState<string>("");
-  const audioRef = useRef<HTMLAudioElement>(null);
+  // 주변 사람 노래를 들을 때 원래 노래를 기억해둘 공간
+  const [originalBgmUrl, setOriginalBgmUrl] = useState<string>("");
 
   useEffect(() => {
     if (audioRef.current) {
+      audioRef.current.volume = 0.2; // 기본 볼륨 설정
       if (bgmUrl) {
         audioRef.current.play().catch(() => {}); // URL 있으면 재생
       } else {
@@ -25,9 +30,32 @@ const MainScreen = () => {
       }
     }
   }, [bgmUrl]);
+  // 2. 재생/일시정지만 제어하는 함수를 만듭니다.
+  const handleTogglePlay = (shouldPlay: boolean) => {
+    if (!audioRef.current) return;
+
+    if (shouldPlay) {
+      audioRef.current.play();
+    } else {
+      audioRef.current.pause();
+    }
+  };
   const handleSelectTrack = (track: Track) => {
     setCurrentTrack(track);
+    setBgmUrl(track.previewUrl);
+    setOriginalBgmUrl(track.previewUrl); // 나중에 돌아올 '진짜 내 노래'로 저장
     setCurrentPage("gps");
+  };
+
+  // GPS 화면(주변 사람들)에서 호출할 재생/복구 로직
+  const handlePlayPeopleMusic = (url: string) => {
+    if (url) {
+      // 주변 사람 노래 재생 (잠시 교체)
+      setBgmUrl(url);
+    } else {
+      // 바텀시트 닫을 때: 원래 내가 듣던 노래(original)로 복구
+      setBgmUrl(originalBgmUrl);
+    }
   };
 
   return (
@@ -46,6 +74,9 @@ const MainScreen = () => {
               onPlusClick={() => setCurrentPage("search")}
               currentTrack={currentTrack}
               onSelectTrack={handleSelectTrack}
+              // 주변 사람 노래 틀 때는 URL을, 닫을 때는 빈 값을 넣도록 GPS를 수정해야 함
+              onPlayPeopleMusic={handlePlayPeopleMusic}
+              onTogglePlay={handleTogglePlay}
             />
           </motion.div>
         ) : (
@@ -57,7 +88,11 @@ const MainScreen = () => {
             className="absolute inset-0 z-50"
           >
             <SearchPage
-              onPlayMusic={(url) => setBgmUrl(url)}
+              onPlayMusic={(url) => {
+                setBgmUrl(url);
+                // SearchPage에서 재생하는 건 '미리듣기' 성격이 강하므로
+                // originalBgmUrl은 바꾸지 않고 bgmUrl만 바꿉니다.
+              }}
               onBack={() => setCurrentPage("gps")}
             />
           </motion.div>


### PR DESCRIPTION
## PR 제목

### PR을 한 이유 🎯

- 기능 수정한것.

### 이슈 번호 📎

- #19 

### 변경사항 🛠

- 메인화면에서 주변사람 음악 누르면 바텀시트 올라오고 음악이 재생되는데 앨범표지 누르면 음악 멈추고, 다시 누르면 멈춘 지점부터 다시 음악이 재생됨. 
- 바텀시트 내리면 음악 멈춤.

