### PR TITLE
[fix] 검색창에서 음악 선택하면 메인화면에 배경음악으로 깔리는.

### DIFF
--- a/sogeun-pwa/src/App.tsx
+++ b/sogeun-pwa/src/App.tsx
@@ -12,13 +12,12 @@ import type { Track } from "./pages/SearchPage";
 
 const MainScreen = () => {
   // 1. 오디오 객체를 담을 ref가 부모에 있어야 합니다.
-  const audioRef = useRef<HTMLAudioElement | null>(null);
   const [currentPage, setCurrentPage] = useState<"gps" | "search">("gps");
   const [currentTrack, setCurrentTrack] = useState<Track | null>(null);
-
   const [bgmUrl, setBgmUrl] = useState<string>("");
-  // 주변 사람 노래를 들을 때 원래 노래를 기억해둘 공간
   const [originalBgmUrl, setOriginalBgmUrl] = useState<string>("");
+
+  const audioRef = useRef<HTMLAudioElement | null>(null);
 
   useEffect(() => {
     if (audioRef.current) {
@@ -74,7 +73,6 @@ const MainScreen = () => {
               onPlusClick={() => setCurrentPage("search")}
               currentTrack={currentTrack}
               onSelectTrack={handleSelectTrack}
-              // 주변 사람 노래 틀 때는 URL을, 닫을 때는 빈 값을 넣도록 GPS를 수정해야 함
               onPlayPeopleMusic={handlePlayPeopleMusic}
               onTogglePlay={handleTogglePlay}
             />
@@ -90,9 +88,8 @@ const MainScreen = () => {
             <SearchPage
               onPlayMusic={(url) => {
                 setBgmUrl(url);
-                // SearchPage에서 재생하는 건 '미리듣기' 성격이 강하므로
-                // originalBgmUrl은 바꾸지 않고 bgmUrl만 바꿉니다.
               }}
+              onSelectTrack={handleSelectTrack} // ✅ 박스 클릭 시 실행될 함수 전달
               onBack={() => setCurrentPage("gps")}
             />
           </motion.div>

--- a/sogeun-pwa/src/pages/SearchPage.tsx
+++ b/sogeun-pwa/src/pages/SearchPage.tsx
@@ -21,6 +21,7 @@ export interface Track {
 interface SearchPageProps {
   onBack: () => void;
   onPlayMusic: (url: string) => void;
+  onSelectTrack: (track: Track) => void;
 }
 
 // 슬라이드 애니메이션 설정
@@ -41,7 +42,11 @@ const slideVariants = {
   }),
 };
 
-const SearchPage: React.FC<SearchPageProps> = ({ onBack, onPlayMusic }) => {
+const SearchPage: React.FC<SearchPageProps> = ({
+  onBack,
+  onPlayMusic,
+  onSelectTrack,
+}) => {
   const [activeTab, setActiveTab] = useState<"search" | "likes">("search");
   const [direction, setDirection] = useState(0);
   const [query, setQuery] = useState("");
@@ -168,7 +173,7 @@ const SearchPage: React.FC<SearchPageProps> = ({ onBack, onPlayMusic }) => {
 
   // [2] 박스 전체 클릭 시: 음악 재생 & GPS 화면으로 이동
   const handleBoxClick = (track: Track) => {
-    onPlayMusic(track.previewUrl); // 음악은 계속 나와야 하니까 재생 요청
+    onSelectTrack(track); // 음악은 계속 나와야 하니까 재생 요청
     const audioEl = document.querySelector("audio");
     if (audioEl) audioEl.volume = 0.2;
     onBack(); // 뒤로 가기


### PR DESCRIPTION
## PR 제목

### PR을 한 이유 🎯

- 검색창 수정

### 이슈 번호 📎

- #19 

### 변경사항 🛠

- 검색창에서 박스 누르면 메인화면으로 넘어가고 배경음악으로 그 선택한 음악 미리듣기 무한재생.

### 특이사항 📌

- 이후에 하단에 이 음악 재생되고 있다는 바 같은거나 기존 now playing 버튼 추가할 예정
- 근데 약간 우리 앱의 차별점넣고싶으면 nowplaying으로 하는게 좋을듯?

